### PR TITLE
Removed "postrotate/endscript" directives

### DIFF
--- a/logrotate.share/acsd
+++ b/logrotate.share/acsd
@@ -1,6 +1,3 @@
 /opt/var/log/acsd.log {
    rotate 2
-   postrotate
-       /usr/bin/killall -HUP syslog-ng
-   endscript
 }

--- a/logrotate.share/afpd
+++ b/logrotate.share/afpd
@@ -1,6 +1,3 @@
 /opt/var/log/afpd.log {
    rotate 2
-   postrotate
-       /usr/bin/killall -HUP syslog-ng
-   endscript
 }

--- a/logrotate.share/bcm63xx
+++ b/logrotate.share/bcm63xx
@@ -1,7 +1,4 @@
 /opt/var/log/bcm63.log {
     monthly
     rotate 1
-    postrotate
-        /usr/bin/killall -HUP syslog-ng
-    endscript
 }

--- a/logrotate.share/bsd
+++ b/logrotate.share/bsd
@@ -1,6 +1,3 @@
 /opt/var/log/bsd.log {
    rotate 2
-   postrotate
-       /usr/bin/killall -HUP syslog-ng
-   endscript
 }

--- a/logrotate.share/crash
+++ b/logrotate.share/crash
@@ -1,7 +1,4 @@
 /opt/var/log/crash.log {
     minsize 1024k
     daily
-    postrotate
-        /usr/bin/killall -HUP syslog-ng
-    endscript
 }

--- a/logrotate.share/diversion
+++ b/logrotate.share/diversion
@@ -1,5 +1,3 @@
 /opt/var/log/diversion.log {
-    postrotate
-        /usr/bin/killall -HUP syslog-ng
-    endscript
+    minsize 512k
 }

--- a/logrotate.share/ethernet
+++ b/logrotate.share/ethernet
@@ -1,5 +1,3 @@
 /opt/var/log/ethernet.log {
-    postrotate
-        /usr/bin/killall -HUP syslog-ng
-    endscript
+    minsize 512k
 }

--- a/logrotate.share/hostapd
+++ b/logrotate.share/hostapd
@@ -1,6 +1,3 @@
 /opt/var/log/hostapd.log {
    rotate 2
-   postrotate
-       /usr/bin/killall -HUP syslog-ng
-   endscript
 }

--- a/logrotate.share/ioctl
+++ b/logrotate.share/ioctl
@@ -1,7 +1,4 @@
 /opt/var/log/ioctl.log {
     monthly
     rotate 1
-    postrotate
-        /usr/bin/killall -HUP syslog-ng
-    endscript
 }

--- a/logrotate.share/jffs
+++ b/logrotate.share/jffs
@@ -2,7 +2,4 @@
     minsize 1024k
     daily
     rotate 1
-    postrotate
-        /usr/bin/killall -HUP syslog-ng
-    endscript
 }

--- a/logrotate.share/meshUDB
+++ b/logrotate.share/meshUDB
@@ -1,5 +1,3 @@
 /opt/var/log/meshUDB.log {
-    postrotate
-        /usr/bin/killall -HUP syslog-ng
-    endscript
+    minsize 512k
 }

--- a/logrotate.share/netdata
+++ b/logrotate.share/netdata
@@ -2,7 +2,4 @@
     minsize 1024k
     daily
     rotate 9
-    postrotate
-        /usr/bin/killall -HUP syslog-ng
-    endscript
 }

--- a/logrotate.share/ntpd
+++ b/logrotate.share/ntpd
@@ -1,5 +1,3 @@
 /opt/var/log/ntp.log {
-    postrotate
-        /usr/bin/killall -HUP syslog-ng
-    endscript
+    minsize 512k
 }

--- a/logrotate.share/openvpn
+++ b/logrotate.share/openvpn
@@ -2,7 +2,4 @@
     minsize 1024k
     daily
     rotate 9
-    postrotate
-        /usr/bin/killall -HUP syslog-ng
-    endscript
 }

--- a/logrotate.share/pixelserv
+++ b/logrotate.share/pixelserv
@@ -2,7 +2,4 @@
     minsize 1024K
     daily
     rotate 9
-    postrotate
-        /usr/bin/killall -HUP syslog-ng
-    endscript
 }

--- a/logrotate.share/roamast
+++ b/logrotate.share/roamast
@@ -1,7 +1,4 @@
 /opt/var/log/roamast.log {
     daily
     rotate 7
-    postrotate
-        /usr/bin/killall -HUP syslog-ng
-    endscript
 }

--- a/logrotate.share/spdmerlin
+++ b/logrotate.share/spdmerlin
@@ -1,5 +1,3 @@
 /opt/var/log/spdmerlin.log {
-    postrotate
-        /usr/bin/killall -HUP syslog-ng
-    endscript
+    minsize 512k
 }

--- a/logrotate.share/suricata
+++ b/logrotate.share/suricata
@@ -2,7 +2,4 @@
     minsize 1024k
     daily
     rotate 9
-    postrotate
-        /usr/bin/killall -HUP syslog-ng
-    endscript
 }


### PR DESCRIPTION
Removed "postrotate/endscript" directive from each individual configuration file since that's already defined in the global set of configuration directives.